### PR TITLE
PLT-7563 Docker images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /dist-newstyle/
 .vscode
 public/app.js
+.pre-commit-config.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Docker Image for Marlowe Runtime
+
+LABEL description="Marlowe Runner"
+
+FROM alpine:3.16.2
+
+RUN apk add darkhttpd \
+    && mkdir marlowe-runner
+
+COPY public/ marlowe-runner/
+
+WORKDIR marlowe-runner
+
+ENV MARLOWE_WEB_SERVER_URL=http://host.containers.internal:3780
+
+EXPOSE 8080
+
+CMD sed -i -e "s|https://marlowe-runtime-preprod-web.scdev.aws.iohkdev.io|$MARLOWE_WEB_SERVER_URL|g" bundle.js \
+    && darkhttpd /marlowe-runner --addr 0.0.0.0 --port 8080

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,226 @@
+version: "2.2"
+
+services:
+
+  node:
+    environment:
+      - NETWORK=${NETWORK:?err}
+    healthcheck:
+      interval: 10s
+      retries: 10
+      test: socat -u OPEN:/dev/null UNIX-CONNECT:/ipc/node.socket
+      timeout: 5s
+    image: inputoutput/cardano-node:1.35.4
+    restart: unless-stopped
+    volumes:
+    - shared:/ipc
+    - node-db:/data
+ 
+  postgres:
+    environment:
+    - POSTGRES_LOGGING=true
+    - POSTGRES_USER=postgres
+    - POSTGRES_PASSWORD=postgres
+    - TZ=UTC
+    healthcheck:
+      interval: 10s
+      retries: 5
+      test: pg_isready -U postgres
+      timeout: 5s
+    image: postgres:11.5-alpine
+    logging:
+      driver: json-file
+      options:
+        max-file: '10'
+        max-size: 200k
+    restart: unless-stopped
+    volumes:
+    - postgres:/var/lib/postgresql/data
+    - ./networks/${NETWORK:?err}/init.sql:/docker-entrypoint-initdb.d/init.sql
+    command:
+      - '-c'
+      - 'max_connections=1000'
+      - '-c'
+      - 'superuser_reserved_connections=5'
+      - '-c'
+      - 'huge_pages=try'
+      - '-c'
+      - 'max_wal_size=6GB'
+      - '-c'
+      - 'max_locks_per_transaction=256'
+      - '-c'
+      - 'max_pred_locks_per_transaction=256'
+      - '-c'
+      - 'work_mem=32MB'
+      - '-c'
+      - 'maintenance_work_mem=256MB'
+    ports:
+    - 5432:5432
+  chain-indexer:
+    environment:
+    - NODE_CONFIG=/node/config.json
+    - DB_NAME=chain_${NETWORK:?err}
+    - DB_USER=postgres
+    - DB_PASS=postgres
+    - DB_HOST=postgres
+    - CARDANO_NODE_SOCKET_PATH=/ipc/node.socket
+    - HTTP_PORT=3781
+    depends_on:
+      node:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    image: ghcr.io/input-output-hk/marlowe-chain-indexer:0.0.4
+    user: 0:0
+    restart: unless-stopped
+    volumes:
+    - shared:/ipc
+    - ./networks/${NETWORK:?err}/node:/node
+ 
+  chain-sync:
+    environment:
+    - NODE_CONFIG=/node/config.json
+    - HOST=0.0.0.0
+    - PORT=3715
+    - QUERY_PORT=3716
+    - JOB_PORT=3720
+    - DB_NAME=chain_${NETWORK:?err}
+    - DB_USER=postgres
+    - DB_PASS=postgres
+    - DB_HOST=postgres
+    - CARDANO_NODE_SOCKET_PATH=/ipc/node.socket
+    - HTTP_PORT=3782
+    depends_on:
+      chain-indexer:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+    image: ghcr.io/input-output-hk/marlowe-chain-sync:0.0.4
+    user: 0:0
+    restart: unless-stopped
+    volumes:
+    - shared:/ipc
+    - ./networks/${NETWORK:?err}/node:/node
+ 
+  indexer:
+    environment:
+    - DB_NAME=chain_${NETWORK:?err}
+    - DB_USER=postgres
+    - DB_PASS=postgres
+    - DB_HOST=postgres
+    - MARLOWE_CHAIN_SYNC_HOST=chain-sync
+    - MARLOWE_CHAIN_SYNC_PORT=3715
+    - MARLOWE_CHAIN_SYNC_QUERY_PORT=3716
+    - MARLOWE_CHAIN_SYNC_COMMAND_PORT=3720
+    - HTTP_PORT=3783
+    depends_on:
+      chain-sync:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+    image: ghcr.io/input-output-hk/marlowe-indexer:0.0.4
+    restart: unless-stopped
+ 
+  sync:
+    environment:
+    - HOST=0.0.0.0
+    - MARLOWE_SYNC_PORT=3724
+    - MARLOWE_HEADER_SYNC_PORT=3725
+    - MARLOWE_QUERY_PORT=3726
+    - DB_NAME=chain_${NETWORK:?err}
+    - MARLOWE_CHAIN_SYNC_HOST=chain-sync
+    - MARLOWE_CHAIN_SYNC_QUERY_PORT=3716
+    - DB_USER=postgres
+    - DB_PASS=postgres
+    - DB_HOST=postgres
+    - HTTP_PORT=3784
+    depends_on:
+      indexer:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+    image: ghcr.io/input-output-hk/marlowe-sync:0.0.4
+    restart: unless-stopped
+ 
+  tx:
+    environment:
+    - HOST=0.0.0.0
+    - PORT=3723
+    - MARLOWE_CHAIN_SYNC_HOST=chain-sync
+    - MARLOWE_CHAIN_SYNC_PORT=3715
+    - MARLOWE_CHAIN_SYNC_QUERY_PORT=3716
+    - MARLOWE_CHAIN_SYNC_COMMAND_PORT=3720
+    - CONTRACT_HOST=contract
+    - CONTRACT_QUERY_PORT=3728
+    - HTTP_PORT=3785
+    depends_on:
+      - chain-sync
+      - contract
+    image: ghcr.io/input-output-hk/marlowe-tx:0.0.4
+    restart: unless-stopped
+ 
+  contract:
+    environment:
+    - HOST=0.0.0.0
+    - PORT=3727
+    - QUERY_PORT=3728
+    - TRANSFER_PORT=3729
+    - STORE_DIR=/store
+    - HTTP_PORT=3787
+    volumes:
+      - marlowe-contract-store:/store
+    image: ghcr.io/input-output-hk/marlowe-contract:0.0.4
+    restart: unless-stopped
+ 
+  proxy:
+    environment:
+    - HOST=0.0.0.0
+    - PORT=3700
+    - TRACED_PORT=3701
+    - TX_HOST=tx
+    - TX_PORT=3723
+    - CONTRACT_HOST=contract
+    - LOAD_PORT=3727
+    - CONTRACT_QUERY_PORT=3728
+    - TRANSFER_PORT=3729
+    - SYNC_HOST=sync
+    - MARLOWE_SYNC_PORT=3724
+    - MARLOWE_HEADER_SYNC_PORT=3725
+    - MARLOWE_QUERY_PORT=3726
+    - HTTP_PORT=3786
+    depends_on:
+      - sync
+      - tx
+      - contract
+    image: ghcr.io/input-output-hk/marlowe-proxy:0.0.4
+    restart: unless-stopped
+    ports:
+    - 3700:3700
+    - 3701:3701
+ 
+  web-server:
+    environment:
+    - PORT=3780
+    - RUNTIME_HOST=proxy
+    - RUNTIME_PORT=3701
+    depends_on:
+      - proxy
+    image: ghcr.io/input-output-hk/marlowe-web-server:0.0.4
+    restart: unless-stopped
+    ports:
+    - 3780:3780
+
+  marlowe-runner:
+    image: docker.io/bwbush/marlowe-runner:latest
+    environment:
+    - MARLOWE_RT_WEBSERVER_URL=${MARLOWE_RT_WEBSERVER_URL:?err}
+    depends_on:
+      - web-server
+    ports:
+      - 8080:8080
+
+volumes:
+  node-db: null
+  postgres: null
+  shared: null
+  marlowe-contract-store: null

--- a/flake.lock
+++ b/flake.lock
@@ -33,6 +33,21 @@
         "type": "github"
       }
     },
+    "blank": {
+      "locked": {
+        "lastModified": 1625557891,
+        "narHash": "sha256-O8/MWsPBGhhyPoPLHZAuoZiiHo9q6FLlEeIDEXuj6T4=",
+        "owner": "divnix",
+        "repo": "blank",
+        "rev": "5a5d2684073d9f563072ed07c871d577a6c614a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "blank",
+        "type": "github"
+      }
+    },
     "blst": {
       "flake": false,
       "locked": {
@@ -101,6 +116,21 @@
         "type": "github"
       }
     },
+    "call-flake": {
+      "locked": {
+        "lastModified": 1687380775,
+        "narHash": "sha256-bmhE1TmrJG4ba93l9WQTLuYM53kwGQAjYHRvHOeuxWU=",
+        "owner": "divnix",
+        "repo": "call-flake",
+        "rev": "74061f6c241227cd05e79b702db9a300a2e4131a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "call-flake",
+        "type": "github"
+      }
+    },
     "cardano-shell": {
       "flake": false,
       "locked": {
@@ -114,6 +144,36 @@
       "original": {
         "owner": "input-output-hk",
         "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "dmerge": {
+      "inputs": {
+        "haumea": [
+          "std",
+          "haumea"
+        ],
+        "nixlib": [
+          "std",
+          "lib"
+        ],
+        "yants": [
+          "std",
+          "yants"
+        ]
+      },
+      "locked": {
+        "lastModified": 1686862774,
+        "narHash": "sha256-ojGtRQ9pIOUrxsQEuEPerUkqIJEuod9hIflfNkY+9CE=",
+        "owner": "divnix",
+        "repo": "dmerge",
+        "rev": "9f7f7a8349d33d7bd02e0f2b484b1f076e503a96",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "ref": "0.2.1",
+        "repo": "dmerge",
         "type": "github"
       }
     },
@@ -271,6 +331,21 @@
         "type": "github"
       }
     },
+    "flake-utils_5": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "ghc-8.6.5-iohk": {
       "flake": false,
       "locked": {
@@ -408,6 +483,28 @@
         "type": "github"
       }
     },
+    "haumea": {
+      "inputs": {
+        "nixpkgs": [
+          "std",
+          "lib"
+        ]
+      },
+      "locked": {
+        "lastModified": 1685133229,
+        "narHash": "sha256-FePm/Gi9PBSNwiDFq3N+DWdfxFq0UKsVVTJS3cQPn94=",
+        "owner": "nix-community",
+        "repo": "haumea",
+        "rev": "34dd58385092a23018748b50f9b23de6266dffc2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "v0.2.2",
+        "repo": "haumea",
+        "type": "github"
+      }
+    },
     "hls-1.10": {
       "flake": false,
       "locked": {
@@ -480,6 +577,27 @@
       "original": {
         "id": "hydra",
         "type": "indirect"
+      }
+    },
+    "incl": {
+      "inputs": {
+        "nixlib": [
+          "std",
+          "lib"
+        ]
+      },
+      "locked": {
+        "lastModified": 1669263024,
+        "narHash": "sha256-E/+23NKtxAqYG/0ydYgxlgarKnxmDbg6rCMWnOBqn9Q=",
+        "owner": "divnix",
+        "repo": "incl",
+        "rev": "ce7bebaee048e4cd7ebdb4cee7885e00c4e2abca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "incl",
+        "type": "github"
       }
     },
     "iogx": {
@@ -555,6 +673,21 @@
         "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
       }
     },
+    "lib": {
+      "locked": {
+        "lastModified": 1694306727,
+        "narHash": "sha256-26fkTOJOI65NOTNKFvtcJF9mzzf/kK9swHzfYt1Dl6Q=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "c30b6a84c0b84ec7aecbe74466033facc9ed103f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "lowdown-src": {
       "flake": false,
       "locked": {
@@ -568,6 +701,25 @@
       "original": {
         "owner": "kristapsdz",
         "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "n2c": {
+      "inputs": {
+        "flake-utils": "flake-utils_5",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1688922987,
+        "narHash": "sha256-RnQwrCD5anqWfyDAVbfFIeU+Ha6cwt5QcIwIkaGRzQw=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "ab381a7d714ebf96a83882264245dbd34f0a7ec8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
         "type": "github"
       }
     },
@@ -768,6 +920,52 @@
         "type": "github"
       }
     },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1677612629,
+        "narHash": "sha256-yC+9LfhfwOd5sXFW8TLnDmqVMNYiHXYPGy9BbdpRqfU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "111ca8e0378e88d9decaa1c6dd7597f35d8bc67f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1675940568,
+        "narHash": "sha256-epG6pOT9V0kS+FUqd7R6/CWkgnZx2DMT5Veqo+y6G3c=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "6ccc4a59c3f1b56d039d93da52696633e641bc71",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nosys": {
+      "locked": {
+        "lastModified": 1668010795,
+        "narHash": "sha256-JBDVBnos8g0toU7EhIIqQ1If5m/nyBqtHhL3sicdPwI=",
+        "owner": "divnix",
+        "repo": "nosys",
+        "rev": "feade0141487801c71ff55623b421ed535dbdefa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "nosys",
+        "type": "github"
+      }
+    },
     "old-ghc-nix": {
       "flake": false,
       "locked": {
@@ -782,6 +980,50 @@
         "owner": "angerman",
         "ref": "master",
         "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "paisano": {
+      "inputs": {
+        "call-flake": "call-flake",
+        "nixpkgs": [
+          "std",
+          "nixpkgs"
+        ],
+        "nosys": "nosys",
+        "yants": [
+          "std",
+          "yants"
+        ]
+      },
+      "locked": {
+        "lastModified": 1693982790,
+        "narHash": "sha256-WTZYlqGUjzzz/PSzcvjEZz2kkwYSXObjeQVrFBaqa2Y=",
+        "owner": "paisano-nix",
+        "repo": "core",
+        "rev": "3e897a19418361ece34841105122ed4f9379ca96",
+        "type": "github"
+      },
+      "original": {
+        "owner": "paisano-nix",
+        "repo": "core",
+        "type": "github"
+      }
+    },
+    "paisano-tui": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1694014205,
+        "narHash": "sha256-u0+T6vMznzfjDMUd01ZXQsrQPMEhMjrQwUPTFsPBR1k=",
+        "owner": "paisano-nix",
+        "repo": "tui",
+        "rev": "587ab9fd07bd969d59df73bfe527b5f8a4e752d1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "paisano-nix",
+        "ref": "0.2.0",
+        "repo": "tui",
         "type": "github"
       }
     },
@@ -811,7 +1053,9 @@
       "inputs": {
         "easyPSSrc": "easyPSSrc",
         "easyPSSrcPaluh": "easyPSSrcPaluh",
-        "iogx": "iogx"
+        "iogx": "iogx",
+        "n2c": "n2c",
+        "std": "std"
       }
     },
     "secp256k1": {
@@ -880,6 +1124,59 @@
         "type": "github"
       }
     },
+    "std": {
+      "inputs": {
+        "arion": [
+          "std",
+          "blank"
+        ],
+        "blank": "blank",
+        "devshell": [
+          "std",
+          "blank"
+        ],
+        "dmerge": "dmerge",
+        "haumea": "haumea",
+        "incl": "incl",
+        "lib": "lib",
+        "makes": [
+          "std",
+          "blank"
+        ],
+        "microvm": [
+          "std",
+          "blank"
+        ],
+        "n2c": [
+          "n2c"
+        ],
+        "nixago": [
+          "std",
+          "blank"
+        ],
+        "nixpkgs": "nixpkgs_4",
+        "paisano": "paisano",
+        "paisano-tui": "paisano-tui",
+        "terranix": [
+          "std",
+          "blank"
+        ],
+        "yants": "yants"
+      },
+      "locked": {
+        "lastModified": 1694941922,
+        "narHash": "sha256-gSuhf+qC3jvOb8am+CTPtIJUH1W3PnU8nzmGVJ2t5eA=",
+        "owner": "divnix",
+        "repo": "std",
+        "rev": "01adf87cf1ed37bcd72a90f2a4e385d76c81c825",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "std",
+        "type": "github"
+      }
+    },
     "systems": {
       "locked": {
         "lastModified": 1681028828,
@@ -922,6 +1219,27 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "yants": {
+      "inputs": {
+        "nixpkgs": [
+          "std",
+          "lib"
+        ]
+      },
+      "locked": {
+        "lastModified": 1686863218,
+        "narHash": "sha256-kooxYm3/3ornWtVBNHM3Zh020gACUyFX2G0VQXnB+mk=",
+        "owner": "divnix",
+        "repo": "yants",
+        "rev": "8f0da0dba57149676aa4817ec0c880fbde7a648d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "yants",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -1,13 +1,148 @@
 {
   "nodes": {
+    "CHaP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1692114433,
+        "narHash": "sha256-l6UoBkt1SUUBga/u0qpQeuNTN2YgtdZMBJSw29Wb0xU=",
+        "owner": "input-output-hk",
+        "repo": "cardano-haskell-packages",
+        "rev": "73093fde5e26b9f7594a2219d339175005256475",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "repo",
+        "repo": "cardano-haskell-packages",
+        "type": "github"
+      }
+    },
+    "HTTP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "blst": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1656163412,
+        "narHash": "sha256-xero1aTe2v4IhWIJaEDUsVDOfE77dOV5zKeHWntHogY=",
+        "owner": "supranational",
+        "repo": "blst",
+        "rev": "03b5124029979755c752eec45f3c29674b558446",
+        "type": "github"
+      },
+      "original": {
+        "owner": "supranational",
+        "repo": "blst",
+        "rev": "03b5124029979755c752eec45f3c29674b558446",
+        "type": "github"
+      }
+    },
+    "cabal-32": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cardano-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "easy-purescript-nix": {
+      "inputs": {
+        "flake-utils": "flake-utils"
+      },
+      "locked": {
+        "lastModified": 1689933391,
+        "narHash": "sha256-jUuy2OzmxegEn0KT3u1uf87eGGA33+of9HodIqS3PLY=",
+        "owner": "justinwoo",
+        "repo": "easy-purescript-nix",
+        "rev": "5dcea83eecb56241ed72e3631d47e87bb11e45b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "justinwoo",
+        "repo": "easy-purescript-nix",
+        "type": "github"
+      }
+    },
     "easyPSSrc": {
       "flake": false,
       "locked": {
-        "lastModified": 1679861376,
-        "narHash": "sha256-LLqaLPJNiap2U8I77K5XVPGJA/Be30Z8lyGOyYXmBlc=",
+        "lastModified": 1689933391,
+        "narHash": "sha256-jUuy2OzmxegEn0KT3u1uf87eGGA33+of9HodIqS3PLY=",
         "owner": "justinwoo",
         "repo": "easy-purescript-nix",
-        "rev": "0c10ff170461aed0c336f5c21ed0f430c2c3574b",
+        "rev": "5dcea83eecb56241ed72e3631d47e87bb11e45b9",
         "type": "github"
       },
       "original": {
@@ -33,13 +168,49 @@
         "type": "github"
       }
     },
-    "flake-utils": {
+    "flake-compat": {
+      "flake": false,
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -48,37 +219,591 @@
         "type": "github"
       }
     },
-    "flakeUtils": {
+    "flake-utils_2": {
       "inputs": {
-        "flake-utils": "flake-utils"
+        "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1657226504,
-        "narHash": "sha256-GIYNjuq4mJlFgqKsZ+YrgzWm0IpA4axA3MCrdKYj7gs=",
-        "owner": "gytis-ivaskevicius",
-        "repo": "flake-utils-plus",
-        "rev": "2bf0f91643c2e5ae38c1b26893ac2927ac9bd82a",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
-        "owner": "gytis-ivaskevicius",
-        "repo": "flake-utils-plus",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1679360468,
+        "narHash": "sha256-LGnza3cfXF10Biw3ZTg0u9o9t7s680Ww200t5KkHTh8=",
+        "owner": "hamishmack",
+        "repo": "flake-utils",
+        "rev": "e1ea268ff47ad475443dbabcd54744b4e5b9d4f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hamishmack",
+        "ref": "hkm/nested-hydraJobs",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "iogx",
+          "pre-commit-hooks-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "hackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1692318155,
+        "narHash": "sha256-e4npK3xeIIIzq1MDFYhpT3cR37DtEttOdGE7uFi71PQ=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "0a259b13134e5ac7f9ca408365fd240bd4b42645",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "haskell-language-server-1_8_0_0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1663402129,
+        "narHash": "sha256-El5wZDn0br/My7cxstRzUyO7VUf1q5V44T55NEQONnI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "855a88238279b795634fa6144a4c0e8acc7e9644",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "855a88238279b795634fa6144a4c0e8acc7e9644",
+        "type": "github"
+      }
+    },
+    "haskell-language-server-1_9_0_0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672051165,
+        "narHash": "sha256-j3XRQTWa7jsVlimaxFZNnlE9IzWII9Prj1/+otks5FQ=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "1916b5782d9f3204d25a1d8f94da4cfd83ae2607",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "1916b5782d9f3204d25a1d8f94da4cfd83ae2607",
+        "type": "github"
+      }
+    },
+    "haskell-nix": {
+      "inputs": {
+        "HTTP": "HTTP",
+        "cabal-32": "cabal-32",
+        "cabal-34": "cabal-34",
+        "cabal-36": "cabal-36",
+        "cardano-shell": "cardano-shell",
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils_3",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
+        "hackage": [
+          "iogx",
+          "hackage"
+        ],
+        "hls-1.10": "hls-1.10",
+        "hls-2.0": "hls-2.0",
+        "hpc-coveralls": "hpc-coveralls",
+        "hydra": "hydra",
+        "iserv-proxy": "iserv-proxy",
+        "nixpkgs": [
+          "iogx",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003",
+        "nixpkgs-2105": "nixpkgs-2105",
+        "nixpkgs-2111": "nixpkgs-2111",
+        "nixpkgs-2205": "nixpkgs-2205",
+        "nixpkgs-2211": "nixpkgs-2211",
+        "nixpkgs-2305": "nixpkgs-2305",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "old-ghc-nix": "old-ghc-nix",
+        "stackage": "stackage"
+      },
+      "locked": {
+        "lastModified": 1692319830,
+        "narHash": "sha256-KD5SPPtJETa83lWr5WwhWWRbSelGhGSkeZ7cqweJfoc=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "90e45988f1ad35d55e890cef16d7b1a5de5e6196",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hls-1.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687698105,
+        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "783905f211ac63edf982dd1889c671653327e441",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hydra": {
+      "inputs": {
+        "nix": "nix",
+        "nixpkgs": [
+          "iogx",
+          "haskell-nix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1671755331,
+        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
+      }
+    },
+    "iogx": {
+      "inputs": {
+        "CHaP": "CHaP",
+        "easy-purescript-nix": "easy-purescript-nix",
+        "flake-utils": "flake-utils_2",
+        "hackage": "hackage",
+        "haskell-language-server-1_8_0_0": "haskell-language-server-1_8_0_0",
+        "haskell-language-server-1_9_0_0": "haskell-language-server-1_9_0_0",
+        "haskell-nix": "haskell-nix",
+        "iohk-nix": "iohk-nix",
+        "nixpkgs": [
+          "iogx",
+          "haskell-nix",
+          "nixpkgs-2305"
+        ],
+        "pre-commit-hooks-nix": "pre-commit-hooks-nix",
+        "sphinxcontrib-haddock": "sphinxcontrib-haddock"
+      },
+      "locked": {
+        "lastModified": 1695236619,
+        "narHash": "sha256-I0So/RNY8QKCtpCyZ0SRDcpY/n+9QB8Uy+FpxZSIKO0=",
+        "owner": "input-output-hk",
+        "repo": "iogx",
+        "rev": "05829ae5f1f2755c47b522f11dc10658f46b1c7a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iogx",
+        "type": "github"
+      }
+    },
+    "iohk-nix": {
+      "inputs": {
+        "blst": "blst",
+        "nixpkgs": [
+          "iogx",
+          "nixpkgs"
+        ],
+        "secp256k1": "secp256k1",
+        "sodium": "sodium"
+      },
+      "locked": {
+        "lastModified": 1691469905,
+        "narHash": "sha256-TV0p1dFGYAMl1dLJEfe/tNFjxvV2H7VgHU1I43q+b84=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "2f3760f135616ebc477d3ed74eba9b63c22f83a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "iserv-proxy": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1688517130,
+        "narHash": "sha256-hUqfxSlo+ffqVdkSZ1EDoB7/ILCL25eYkcCXW9/P3Wc=",
+        "ref": "hkm/remote-iserv",
+        "rev": "9151db2a9a61d7f5fe52ff8836f18bbd0fd8933c",
+        "revCount": 13,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+      },
+      "original": {
+        "ref": "hkm/remote-iserv",
+        "type": "git",
+        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+      }
+    },
+    "lowdown-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "lowdown-src": "lowdown-src",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1661606874,
+        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.11.0",
+        "repo": "nix",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669809720,
-        "narHash": "sha256-RMT77f6CPOYtLLQ2esj+EJ1BPVWxf4RDidjrSvA5OhI=",
-        "owner": "nixos",
+        "lastModified": 1657693803,
+        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "227de2b3bbec142f912c09d5e8a1b4e778aa54fb",
+        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105": {
+      "locked": {
+        "lastModified": 1659914493,
+        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111": {
+      "locked": {
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2205": {
+      "locked": {
+        "lastModified": 1685573264,
+        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2211": {
+      "locked": {
+        "lastModified": 1688392541,
+        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2305": {
+      "locked": {
+        "lastModified": 1690680713,
+        "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1690720142,
+        "narHash": "sha256-GywuiZjBKfFkntQwpNQfL+Ksa2iGjPprBGL0/psgRZM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3acb5c4264c490e7714d503c7166a3fde0c51324",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1689261696,
+        "narHash": "sha256-LzfUtFs9MQRvIoQ3MfgSuipBVMXslMPH/vZ+nM40LkA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "df1eee2aa65052a18121ed4971081576b25d6b5c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_4",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1692274144,
+        "narHash": "sha256-BxTQuRUANQ81u8DJznQyPmRsg63t4Yc+0kcyq6OLz8s=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "7e3517c03d46159fdbf8c0e5c97f82d5d4b0c8fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
         "type": "github"
       }
     },
@@ -86,8 +811,118 @@
       "inputs": {
         "easyPSSrc": "easyPSSrc",
         "easyPSSrcPaluh": "easyPSSrcPaluh",
-        "flakeUtils": "flakeUtils",
-        "nixpkgs": "nixpkgs"
+        "iogx": "iogx"
+      }
+    },
+    "secp256k1": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1683999695,
+        "narHash": "sha256-9nJJVENMXjXEJZzw8DHzin1DkFkF8h9m/c6PuM7Uk4s=",
+        "owner": "bitcoin-core",
+        "repo": "secp256k1",
+        "rev": "acf5c55ae6a94e5ca847e07def40427547876101",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitcoin-core",
+        "ref": "v0.3.2",
+        "repo": "secp256k1",
+        "type": "github"
+      }
+    },
+    "sodium": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675156279,
+        "narHash": "sha256-0uRcN5gvMwO7MCXVYnoqG/OmeBFi8qRVnDWJLnBb9+Y=",
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      }
+    },
+    "sphinxcontrib-haddock": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1594136664,
+        "narHash": "sha256-O9YT3iCUBHP3CEF88VDLLCO2HSP3HqkNA2q2939RnVY=",
+        "owner": "michaelpj",
+        "repo": "sphinxcontrib-haddock",
+        "rev": "f3956b3256962b2d27d5a4e96edb7951acf5de34",
+        "type": "github"
+      },
+      "original": {
+        "owner": "michaelpj",
+        "repo": "sphinxcontrib-haddock",
+        "type": "github"
+      }
+    },
+    "stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1692317324,
+        "narHash": "sha256-AofEuurJHrfMljrCAkMKTWBC5xGluhBZiAfHQ73224Y=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "4812a420235589a74f9278cca81f6dbf74ffb42f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -33,8 +33,5 @@
       "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
     ];
     allow-import-from-derivation = true;
-    permittedInsecurePackages = [
-      "python-2.7.18.6"
-    ];
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,13 @@
 {
   description = "Change the description field in your flake.nix";
 
-
   inputs = {
     iogx.url = "github:input-output-hk/iogx";
+    n2c.url = "github:nlewo/nix2container";
+    std = {
+      url = "github:divnix/std";   
+      inputs.n2c.follows = "n2c";
+    };
     easyPSSrc = {
       flake = false;
       url = "github:justinwoo/easy-purescript-nix";
@@ -17,13 +21,17 @@
     };
   };
 
-
   outputs = inputs: inputs.iogx.lib.mkFlake {
     inherit inputs;
     repoRoot = ./.;
-    # systems = ["x86_64-linux" "x86_64-darwin"];
+    systems = ["x86_64-linux"];
+    nixpkgsConfig = {
+      permittedInsecurePackages = [
+        "nodejs-16.20.1"
+        "python-2.7.18.6"
+      ];
+    };
   };
-
 
   nixConfig = {
     extra-substituters = [

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,12 @@
+# This file is part of the IOGX template and is documented at the link below:
+# https://www.github.com/input-output-hk/iogx#31-flakenix
+
 {
-  # nixConfig = {
-  #   bash-prompt-suffix = "[dev]";
-  # };
+  description = "Change the description field in your flake.nix";
+
+
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    flakeUtils.url = "github:gytis-ivaskevicius/flake-utils-plus";
+    iogx.url = "github:input-output-hk/iogx";
     easyPSSrc = {
       flake = false;
       url = "github:justinwoo/easy-purescript-nix";
@@ -15,54 +17,24 @@
     };
   };
 
-  outputs = { self, nixpkgs, flakeUtils, easyPSSrc, easyPSSrcPaluh, ... }:
-    flakeUtils.lib.eachSystem ["x86_64-linux"] (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-        easyPS = pkgs.callPackage easyPSSrc { inherit pkgs; };
-        easyPSPaluh = pkgs.callPackage easyPSSrcPaluh { inherit pkgs; };
-        nodejs-16 = pkgs.writeShellScriptBin "nodejs-16" ''
-          ${ pkgs.nodejs-16_x.out}/bin/node $@
-        '';
-      in {
-        devShell = pkgs.mkShell {
-          buildInputs = [
 
-            # Please update spago and purescript in `package.json` `scripts` section
-            easyPSPaluh."purs-0_15_10_0"
-            easyPSPaluh."purs-tidy"
-            easyPS.purescript-language-server
-            easyPS.pscid
-            # easyPS.purs-tidy
-            easyPS.pulp
-            easyPS.spago
+  outputs = inputs: inputs.iogx.lib.mkFlake {
+    inherit inputs;
+    repoRoot = ./.;
+    # systems = ["x86_64-linux" "x86_64-darwin"];
+  };
 
-            pkgs.jq
-            pkgs.docker
-            pkgs.nodePackages.bower
-            pkgs.nodePackages.jshint
-            pkgs.nodePackages.nodemon
-            pkgs.nodePackages.yarn
-            pkgs.nodePackages.webpack
-            pkgs.nodePackages.webpack-cli
-            pkgs.nodePackages.webpack-dev-server
-            pkgs.dhall
-            pkgs.nodejs-18_x
-            nodejs-16
-            pkgs.pkgconfig
-            pkgs.postgresql
-            pkgs.python27
-            pkgs.python37
-            pkgs.unzip
-            pkgs.nixpacks
-        ];
-        shellHook = ''
-          npm install
-          NODE_OPTIONS=--experimental-fetch --trace-warnings
-          export PATH=$PATH:./node_modules/.bin/:./bin
-          export PS1="\n\[\033[1;32m\][nix develop:\w]\$\[\033[0m\] ";
-        '';
-      };
-    }
-  );
+
+  nixConfig = {
+    extra-substituters = [
+      "https://cache.iog.io"
+    ];
+    extra-trusted-public-keys = [
+      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+    ];
+    allow-import-from-derivation = true;
+    permittedInsecurePackages = [
+      "python-2.7.18.6"
+    ];
+  };
 }

--- a/make-docker-image.sh
+++ b/make-docker-image.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+
+set -eo pipefail
+
+export MARLOWE_WEB_SERVER_URL=https://marlowe-runtime-preprod-web.scdev.aws.iohkdev.io
+
+spago build
+webpack-cli bundle --mode=production -c webpack.js --no-watch
+
+DOCKER_HASH=$(podman build --tag marlowe-runner . | tail -n 1)
+
+echo 'Push to docker using the following command:'
+echo '  podman push '"$DOCKER_HASH"' \'
+echo '    docker://docker.io/myrepo/marlowe-runner'
+echo
+echo 'To run the image, specify both the `MARLOWE_WEB_SERVER_URL` for the Marlowe'
+echo 'Runtime web server instance and the port (default 8080) where the container'
+echo 'exposes Marlower Runner. For example,'
+echo '  podman run -p 8123:8080 \'
+echo '    -e MARLOWE_WEB_SERVER_URL=http://192.168.0.12:13780 \'
+echo "    $DOCKER_HASH"

--- a/make-docker-image.sh
+++ b/make-docker-image.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC3040
 
 set -eo pipefail
 
@@ -10,12 +11,12 @@ webpack-cli bundle --mode=production -c webpack.js --no-watch
 DOCKER_HASH=$(podman build --tag marlowe-runner . | tail -n 1)
 
 echo 'Push to docker using the following command:'
-echo '  podman push '"$DOCKER_HASH"' \'
+echo '  podman push '"$DOCKER_HASH"' '\\
 echo '    docker://docker.io/myrepo/marlowe-runner'
 echo
-echo 'To run the image, specify both the `MARLOWE_WEB_SERVER_URL` for the Marlowe'
+echo 'To run the image, specify both the MARLOWE_WEB_SERVER_URL for the Marlowe'
 echo 'Runtime web server instance and the port (default 8080) where the container'
 echo 'exposes Marlower Runner. For example,'
-echo '  podman run -p 8123:8080 \'
-echo '    -e MARLOWE_WEB_SERVER_URL=http://192.168.0.12:13780 \'
+echo '  podman run -p 8123:8080 '\\
+echo '    -e MARLOWE_WEB_SERVER_URL=http://192.168.0.12:13780 '\\
 echo "    $DOCKER_HASH"

--- a/nix/cabal-project.nix
+++ b/nix/cabal-project.nix
@@ -1,0 +1,13 @@
+# This file is part of the IOGX template and is documented at the link below:
+# https://www.github.com/input-output-hk/iogx#33-nixcabal-projectnix
+
+{ iogxRepoRoot, repoRoot, inputs, inputs', pkgs, system, lib, meta, config, ... }:
+
+{
+  # cabalProjectLocal = "";
+  # sha256map = {};
+  # shellWithHoogle = false; 
+  # shellBuildInputs = [];
+  # modules = {};
+  # overlays = [];
+}

--- a/nix/cabal-project.nix
+++ b/nix/cabal-project.nix
@@ -4,10 +4,10 @@
 { iogxRepoRoot, repoRoot, inputs, inputs', pkgs, system, lib, meta, config, ... }:
 
 {
-  # cabalProjectLocal = "";
-  # sha256map = {};
-  # shellWithHoogle = false; 
-  # shellBuildInputs = [];
-  # modules = {};
-  # overlays = [];
+# cabalProjectLocal = "";
+# sha256map = {};
+# shellWithHoogle = false; 
+# shellBuildInputs = [];
+# modules = {};
+# overlays = [];
 }

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -1,0 +1,10 @@
+# This file is part of the IOGX template and is documented at the link below:
+# https://www.github.com/input-output-hk/iogx#39-nixcinix
+
+{ iogxRepoRoot, repoRoot, inputs, inputs', pkgs, system, lib, ... }:
+
+{
+  # includeDefaultOutputs = true;
+  # includedPaths = [];
+  # excludedPaths = [];
+}

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -4,7 +4,7 @@
 { iogxRepoRoot, repoRoot, inputs, inputs', pkgs, system, lib, ... }:
 
 {
-  # includeDefaultOutputs = true;
-  # includedPaths = [];
-  # excludedPaths = [];
+# includeDefaultOutputs = true;
+# includedPaths = [];
+# excludedPaths = [];
 }

--- a/nix/formatters.nix
+++ b/nix/formatters.nix
@@ -4,33 +4,33 @@
 { iogxRepoRoot, repoRoot, inputs, inputs', pkgs, system, lib, ... }:
 
 {
-# cabal-fmt.enable = false;
-# cabal-fmt.extraOptions = "";
+  # cabal-fmt.enable = false;
+  # cabal-fmt.extraOptions = "";
 
-# stylish-haskell.enable = false;
-# stylish-haskell.extraOptions = "";
+  # stylish-haskell.enable = false;
+  # stylish-haskell.extraOptions = "";
 
-# shellcheck.enable = false;
-# shellcheck.extraOptions = "";
+  shellcheck.enable = true;
+  shellcheck.extraOptions = "";
 
-# prettier.enable = false;
-# prettier.extraOptions = "";
+  # prettier.enable = false;
+  # prettier.extraOptions = "";
 
-# editorconfig-checker.enable = false;
-# editorconfig-checker.extraOptions = "";
+  # editorconfig-checker.enable = false;
+  # editorconfig-checker.extraOptions = "";
 
-  nixpkgs-fmt.enable = false;
+  nixpkgs-fmt.enable = true;
   nixpkgs-fmt.extraOptions = "";
 
-# png-optimization.enable = false;
-# png-optimization.extraOptions = "";
+  # png-optimization.enable = false;
+  # png-optimization.extraOptions = "";
 
-# fourmolu.enable = false;
-# fourmolu.extraOptions = "";
+  # fourmolu.enable = false;
+  # fourmolu.extraOptions = "";
 
-  purs-tidy.enable = false;
+  purs-tidy.enable = true;
   purs-tidy.extraOptions = "";
 
-# hlint.enable = false;
-# hlint.extraOptions = "";
+  # hlint.enable = false;
+  # hlint.extraOptions = "";
 }

--- a/nix/formatters.nix
+++ b/nix/formatters.nix
@@ -1,0 +1,36 @@
+# This file is part of the IOGX template and is documented at the link below:
+# https://www.github.com/input-output-hk/iogx#38-nixformattersnix
+
+{ iogxRepoRoot, repoRoot, inputs, inputs', pkgs, system, lib, ... }:
+
+{
+  # cabal-fmt.enable = false;
+  # cabal-fmt.extraOptions = "";
+
+  # stylish-haskell.enable = false;
+  # stylish-haskell.extraOptions = "";
+
+  # shellcheck.enable = false;
+  # shellcheck.extraOptions = "";
+
+  # prettier.enable = false;
+  # prettier.extraOptions = "";
+
+  # editorconfig-checker.enable = false;
+  # editorconfig-checker.extraOptions = "";
+
+  # nixpkgs-fmt.enable = false;
+  # nixpkgs-fmt.extraOptions = "";
+
+  # png-optimization.enable = false;
+  # png-optimization.extraOptions = "";
+
+  # fourmolu.enable = false;
+  # fourmolu.extraOptions = "";
+
+  # purs-tidy.enable = false;
+  # purs-tidy.extraOptions = "";
+
+  # hlint.enable = false;
+  # hlint.extraOptions = "";
+}

--- a/nix/formatters.nix
+++ b/nix/formatters.nix
@@ -4,33 +4,33 @@
 { iogxRepoRoot, repoRoot, inputs, inputs', pkgs, system, lib, ... }:
 
 {
-  # cabal-fmt.enable = false;
-  # cabal-fmt.extraOptions = "";
+# cabal-fmt.enable = false;
+# cabal-fmt.extraOptions = "";
 
-  # stylish-haskell.enable = false;
-  # stylish-haskell.extraOptions = "";
+# stylish-haskell.enable = false;
+# stylish-haskell.extraOptions = "";
 
-  # shellcheck.enable = false;
-  # shellcheck.extraOptions = "";
+# shellcheck.enable = false;
+# shellcheck.extraOptions = "";
 
-  # prettier.enable = false;
-  # prettier.extraOptions = "";
+# prettier.enable = false;
+# prettier.extraOptions = "";
 
-  # editorconfig-checker.enable = false;
-  # editorconfig-checker.extraOptions = "";
+# editorconfig-checker.enable = false;
+# editorconfig-checker.extraOptions = "";
 
-  # nixpkgs-fmt.enable = false;
-  # nixpkgs-fmt.extraOptions = "";
+  nixpkgs-fmt.enable = false;
+  nixpkgs-fmt.extraOptions = "";
 
-  # png-optimization.enable = false;
-  # png-optimization.extraOptions = "";
+# png-optimization.enable = false;
+# png-optimization.extraOptions = "";
 
-  # fourmolu.enable = false;
-  # fourmolu.extraOptions = "";
+# fourmolu.enable = false;
+# fourmolu.extraOptions = "";
 
-  # purs-tidy.enable = false;
-  # purs-tidy.extraOptions = "";
+  purs-tidy.enable = false;
+  purs-tidy.extraOptions = "";
 
-  # hlint.enable = false;
-  # hlint.extraOptions = "";
+# hlint.enable = false;
+# hlint.extraOptions = "";
 }

--- a/nix/per-system-outputs.nix
+++ b/nix/per-system-outputs.nix
@@ -4,11 +4,11 @@
 { iogxRepoRoot, repoRoot, inputs, inputs', pkgs, system, lib, projects ? null, ... }:
 
 {
-  # packages = { };
-  # checks = { };
-  # apps = { };
-  # operables = { };
-  # oci-images = { };
-  # nomadTasks = { };
-  # foobar = { };
+# packages = { };
+# checks = { };
+# apps = { };
+# operables = { };
+# oci-images = { };
+# nomadTasks = { };
+# foobar = { };
 }

--- a/nix/per-system-outputs.nix
+++ b/nix/per-system-outputs.nix
@@ -1,0 +1,14 @@
+# This file is part of the IOGX template and is documented at the link below:
+# https://www.github.com/input-output-hk/iogx#35-nixper-system-outputsnix
+
+{ iogxRepoRoot, repoRoot, inputs, inputs', pkgs, system, lib, projects ? null, ... }:
+
+{
+  # packages = { };
+  # checks = { };
+  # apps = { };
+  # operables = { };
+  # oci-images = { };
+  # nomadTasks = { };
+  # foobar = { };
+}

--- a/nix/read-the-docs.nix
+++ b/nix/read-the-docs.nix
@@ -1,0 +1,8 @@
+# This file is part of the IOGX template and is documented at the link below:
+# https://www.github.com/input-output-hk/iogx#37-nixread-the-docsnix
+
+{ iogxRepoRoot, repoRoot, inputs, inputs', pkgs, system, lib, ... }:
+
+{
+  # siteFolder = null;
+}

--- a/nix/read-the-docs.nix
+++ b/nix/read-the-docs.nix
@@ -4,5 +4,5 @@
 { iogxRepoRoot, repoRoot, inputs, inputs', pkgs, system, lib, ... }:
 
 {
-  # siteFolder = null;
+# siteFolder = null;
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -7,9 +7,9 @@ let
 
   easyPS = pkgs.callPackage inputs.easyPSSrc { inherit pkgs; };
   easyPSPaluh = pkgs.callPackage inputs.easyPSSrcPaluh { inherit pkgs; };
-  nodejs-16 = pkgs.writeShellScriptBin "nodejs-16" ''
-    ${ pkgs.nodejs-16_x.out}/bin/node $@
-  '';
+# nodejs-16 = pkgs.writeShellScriptBin "nodejs-16" ''
+#   ${ pkgs.nodejs-16_x.out}/bin/node $@
+# '';
 
 in
 
@@ -27,7 +27,7 @@ in
       easyPS.pulp
       easyPS.spago
       pkgs.jq
-      pkgs.docker
+    # pkgs.docker
       pkgs.nodePackages.bower
       pkgs.nodePackages.jshint
       pkgs.nodePackages.nodemon
@@ -37,10 +37,10 @@ in
       pkgs.nodePackages.webpack-dev-server
       pkgs.dhall
       pkgs.nodejs-18_x
-      nodejs-16
+    # nodejs-16
       pkgs.pkg-config
       pkgs.postgresql
-      pkgs.python27
+    # pkgs.python27
       pkgs.python38
       pkgs.unzip
       pkgs.nixpacks

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -18,8 +18,7 @@ in
     # prompt = "$ ";
     welcomeMessage = "Marlowe Runner";
     packages = [
-      pkgs.node2nix
-      easyPS.spago2nix
+      pkgs.podman
       # Please update spago and purescript in `package.json` `scripts` section
       easyPSPaluh."purs-0_15_10_0"
       easyPSPaluh."purs-tidy"

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -7,9 +7,9 @@ let
 
   easyPS = pkgs.callPackage inputs.easyPSSrc { inherit pkgs; };
   easyPSPaluh = pkgs.callPackage inputs.easyPSSrcPaluh { inherit pkgs; };
-# nodejs-16 = pkgs.writeShellScriptBin "nodejs-16" ''
-#   ${ pkgs.nodejs-16_x.out}/bin/node $@
-# '';
+  nodejs-16 = pkgs.writeShellScriptBin "nodejs-16" ''
+    ${ pkgs.nodejs-16_x.out}/bin/node $@
+  '';
 
 in
 
@@ -18,6 +18,8 @@ in
     # prompt = "$ ";
     welcomeMessage = "Marlowe Runner";
     packages = [
+      pkgs.node2nix
+      easyPS.spago2nix
       # Please update spago and purescript in `package.json` `scripts` section
       easyPSPaluh."purs-0_15_10_0"
       easyPSPaluh."purs-tidy"
@@ -27,7 +29,7 @@ in
       easyPS.pulp
       easyPS.spago
       pkgs.jq
-    # pkgs.docker
+      pkgs.docker
       pkgs.nodePackages.bower
       pkgs.nodePackages.jshint
       pkgs.nodePackages.nodemon
@@ -37,19 +39,19 @@ in
       pkgs.nodePackages.webpack-dev-server
       pkgs.dhall
       pkgs.nodejs-18_x
-    # nodejs-16
+      nodejs-16
       pkgs.pkg-config
       pkgs.postgresql
-    # pkgs.python27
+      pkgs.python27
       pkgs.python38
       pkgs.unzip
       pkgs.nixpacks
     ];
-    # scripts = { };
-    # env = { };
+  # scripts = { };
+  # env = { };
     enterShell = ''
       npm install
-      NODE_OPTIONS=--experimental-fetch --trace-warnings
-      export PATH=$PATH:./node_modules/.bin/:./bin
+      NODE_OPTIONS="--experimental-fetch --trace-warnings"
+      export PATH="$PATH:./node_modules/.bin/:./bin"
     '';
   }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,55 @@
+# This file is part of the IOGX template and is documented at the link below:
+# https://www.github.com/input-output-hk/iogx#34-nixshellnix
+
+{ iogxRepoRoot, repoRoot, inputs, inputs', pkgs, system, lib, project ? null, ... }:
+
+let
+
+  easyPS = pkgs.callPackage inputs.easyPSSrc { inherit pkgs; };
+  easyPSPaluh = pkgs.callPackage inputs.easyPSSrcPaluh { inherit pkgs; };
+  nodejs-16 = pkgs.writeShellScriptBin "nodejs-16" ''
+    ${ pkgs.nodejs-16_x.out}/bin/node $@
+  '';
+
+in
+
+  {
+    # name = "nix-shell";
+    # prompt = "$ ";
+    welcomeMessage = "Marlowe Runner";
+    packages = [
+      # Please update spago and purescript in `package.json` `scripts` section
+      easyPSPaluh."purs-0_15_10_0"
+      easyPSPaluh."purs-tidy"
+      easyPS.purescript-language-server
+      easyPS.pscid
+    # easyPS.purs-tidy
+      easyPS.pulp
+      easyPS.spago
+      pkgs.jq
+      pkgs.docker
+      pkgs.nodePackages.bower
+      pkgs.nodePackages.jshint
+      pkgs.nodePackages.nodemon
+      pkgs.nodePackages.yarn
+      pkgs.nodePackages.webpack
+      pkgs.nodePackages.webpack-cli
+      pkgs.nodePackages.webpack-dev-server
+      pkgs.dhall
+      pkgs.nodejs-18_x
+      nodejs-16
+      pkgs.pkg-config
+      pkgs.postgresql
+      pkgs.python27
+      pkgs.python38
+      pkgs.unzip
+      pkgs.nixpacks
+    ];
+    # scripts = { };
+    # env = { };
+    enterShell = ''
+      npm install
+      NODE_OPTIONS=--experimental-fetch --trace-warnings
+      export PATH=$PATH:./node_modules/.bin/:./bin
+    '';
+  }

--- a/nix/top-level-outputs.nix
+++ b/nix/top-level-outputs.nix
@@ -1,0 +1,6 @@
+# This file is part of the IOGX template and is documented at the link below:
+# https://www.github.com/input-output-hk/iogx#36-nixtop-level-outputsnix
+
+{ repoRoot, inputs, lib, ... }:
+
+{ }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "marlowe-runner",
       "hasInstallScript": true,
       "dependencies": {
         "@dcspark/cardano-multiplatform-lib-browser": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name" : "marlowe-runner",
   "dependencies": {
     "@dcspark/cardano-multiplatform-lib-browser": "^3.1.2",
     "@dcspark/cardano-multiplatform-lib-nodejs": "^3.1.2",

--- a/src/Component/App.purs
+++ b/src/Component/App.purs
@@ -167,12 +167,12 @@ mkApp = do
           -- FIXME: Make this loop a bit smarter and after some time stop trying and notify
           -- the user that we give up.
           resyncLoop contractId = case possibleSyncFn of
-              Nothing -> pure unit
-              Just sync -> for_ (1..30) \_ -> do
-                delay (Milliseconds 5000.0)
-                sync contractId `catchError` \err -> do
-                  traceM $ "error during sync" <> unsafeStringify err
-                  pure unit
+            Nothing -> pure unit
+            Just sync -> for_ (1 .. 30) \_ -> do
+              delay (Milliseconds 5000.0)
+              sync contractId `catchError` \err -> do
+                traceM $ "error during sync" <> unsafeStringify err
+                pure unit
 
           add :: ContractInfo.ContractCreated -> Effect Unit
           add cc@(ContractInfo.ContractCreated { contractId }) = do
@@ -181,7 +181,7 @@ mkApp = do
               ContractInfoMap.insertContractCreated cc contractMap /\ initialized
 
           update :: ContractInfo.ContractUpdated -> Effect Unit
-          update cu@(ContractInfo.ContractUpdated { contractInfo: ContractInfo { contractId }}) = do
+          update cu@(ContractInfo.ContractUpdated { contractInfo: ContractInfo { contractId } }) = do
             launchAff_ $ resyncLoop contractId
             updateContractInfoMap $ \(contractMap /\ initialized) ->
               ContractInfoMap.insertContractUpdated cu contractMap /\ initialized

--- a/src/Component/ApplyInputs.purs
+++ b/src/Component/ApplyInputs.purs
@@ -320,16 +320,16 @@ mkChoiceFormComponent = do
         ]
     pure $ wrappedContentWithFooter body actions
 
-    -- pure $ BodyLayout.component do
+-- pure $ BodyLayout.component do
 
-    --   { title: DOM.div { className: "" }
-    --       [ DOM.div { className: "mb-3" } $ DOOM.img { src: "/images/magnifying_glass.svg" }
-    --       , DOM.div { className: "mb-3" } $ DOOM.text "Advance the contract"
-    --       ]
+--   { title: DOM.div { className: "" }
+--       [ DOM.div { className: "mb-3" } $ DOOM.img { src: "/images/magnifying_glass.svg" }
+--       , DOM.div { className: "mb-3" } $ DOOM.text "Advance the contract"
+--       ]
 
-    --   , description: DOM.p { className: "mb-3" } "Progress through the contract by delving into its specifics. Analyse the code, evaluate the graph and apply the required inputs. This stage is crucial for ensuring the contract advances correctly so take a moment to confirm all details."
-    --   , content: wrappedContentWithFooter body actions
-    --   }
+--   , description: DOM.p { className: "mb-3" } "Progress through the contract by delving into its specifics. Analyse the code, evaluate the graph and apply the required inputs. This stage is crucial for ensuring the contract advances correctly so take a moment to confirm all details."
+--   , content: wrappedContentWithFooter body actions
+--   }
 
 type NotifyFormComponentProps =
   { notifyInput :: NotifyInput
@@ -813,7 +813,6 @@ onStateTransition contractInfo onSuccess _ prevState (Machine.InputApplied ia) =
 onStateTransition _ _ onErrors prev next = do
   void $ for (Machine.stateErrors next) onErrors
 
-
 mkComponent :: MkComponentM (Props -> JSX)
 mkComponent = do
   runtime <- asks _.runtime
@@ -934,7 +933,7 @@ mkComponent = do
             environment <- Machine.stateEnvironment machine.state
             inputChoices <- Machine.stateInputChoices machine.state
             pure { environment, inputChoices }
-        case ctx  of
+        case ctx of
           Nothing -> DOOM.text "Should rather not happen ;-)"
           Just { environment, inputChoices } -> do
             let
@@ -989,39 +988,40 @@ mkComponent = do
                     setSubmitting true
                     applyPickInputSucceeded Nothing
                 }
-      -- Machine.PickingInput { errors: Just error } -> do
-      --   DOOM.text error
-      -- Machine.CreatingTx { errors } -> do
-      --   -- DetailedFlow _ -> do
-      --   --   creatingTxDetails Nothing onDismiss "createTx placeholder" $ case errors of
-      --   --     Just err -> Just $ err
-      --   --     Nothing -> Nothing
-      --   let
-      --     body = DOOM.text "Auto creating tx..."
-      --   showPossibleErrorAndDismiss "Creating Transaction" "" body onDismiss errors
-      -- -- SimplifiedFlow -> BodyLayout.component
-      -- --   { title: "Creating transaction"
-      -- --   , description: DOOM.text "We are creating the initial transaction."
-      -- --   , content: DOOM.text "Auto creating tx... (progress bar?)"
-      -- --   }
-      -- Machine.SigningTx { createTxResponse, errors } -> do
-      --   -- DetailedFlow { showPrevStep: true } -> do
-      --   --   creatingTxDetails (Just setNextFlow) onDismiss "createTx placeholder" $ Just createTxResponse
-      --   -- DetailedFlow _ ->
-      --   --   signingTransaction Nothing onDismiss Nothing
-      --   let
-      --     body = DOOM.text "Auto signing tx... (progress bar?)"
-      --   showPossibleErrorAndDismiss "Signing Transaction" "" body onDismiss errors
-      -- Machine.SubmittingTx { txWitnessSet, errors } ->
-      --   -- DetailedFlow { showPrevStep: true } -> do
-      --   --   signingTransaction (Just setNextFlow) onDismiss $ Just txWitnessSet
-      --   -- DetailedFlow _ ->
-      --   --   submittingTransaction onDismiss "Final request placeholder" $ errors
-      --   BodyLayout.component
-      --     { title: DOM.h3 {} $ DOOM.text "Submitting transaction"
-      --     , description: DOOM.text "We are submitting the initial transaction."
-      --     , content: DOOM.text "Auto submitting tx... (progress bar?)"
-      --     }
+
+-- Machine.PickingInput { errors: Just error } -> do
+--   DOOM.text error
+-- Machine.CreatingTx { errors } -> do
+--   -- DetailedFlow _ -> do
+--   --   creatingTxDetails Nothing onDismiss "createTx placeholder" $ case errors of
+--   --     Just err -> Just $ err
+--   --     Nothing -> Nothing
+--   let
+--     body = DOOM.text "Auto creating tx..."
+--   showPossibleErrorAndDismiss "Creating Transaction" "" body onDismiss errors
+-- -- SimplifiedFlow -> BodyLayout.component
+-- --   { title: "Creating transaction"
+-- --   , description: DOOM.text "We are creating the initial transaction."
+-- --   , content: DOOM.text "Auto creating tx... (progress bar?)"
+-- --   }
+-- Machine.SigningTx { createTxResponse, errors } -> do
+--   -- DetailedFlow { showPrevStep: true } -> do
+--   --   creatingTxDetails (Just setNextFlow) onDismiss "createTx placeholder" $ Just createTxResponse
+--   -- DetailedFlow _ ->
+--   --   signingTransaction Nothing onDismiss Nothing
+--   let
+--     body = DOOM.text "Auto signing tx... (progress bar?)"
+--   showPossibleErrorAndDismiss "Signing Transaction" "" body onDismiss errors
+-- Machine.SubmittingTx { txWitnessSet, errors } ->
+--   -- DetailedFlow { showPrevStep: true } -> do
+--   --   signingTransaction (Just setNextFlow) onDismiss $ Just txWitnessSet
+--   -- DetailedFlow _ ->
+--   --   submittingTransaction onDismiss "Final request placeholder" $ errors
+--   BodyLayout.component
+--     { title: DOM.h3 {} $ DOOM.text "Submitting transaction"
+--     , description: DOOM.text "We are submitting the initial transaction."
+--     , content: DOOM.text "Auto submitting tx... (progress bar?)"
+--     }
 
 address :: String
 address = "addr_test1qz4y0hs2kwmlpvwc6xtyq6m27xcd3rx5v95vf89q24a57ux5hr7g3tkp68p0g099tpuf3kyd5g80wwtyhr8klrcgmhasu26qcn"

--- a/src/Component/ApplyInputs/Machine.purs
+++ b/src/Component/ApplyInputs/Machine.purs
@@ -233,7 +233,7 @@ step state action = do
       FetchRequiredWalletContextFailed error -> FetchingRequiredWalletContext $ r { errors = Just error }
       FetchRequiredWalletContextSucceeded { requiredWalletContext, allInputsChoices, environment } -> case allInputsChoices of
         Left contract -> do
-          let inputChoices  = AdvanceContract contract
+          let inputChoices = AdvanceContract contract
           PickingInput
             { autoRun
             , errors: Nothing
@@ -250,10 +250,10 @@ step state action = do
               let
                 countInputType :: forall a. Maybe a -> Int
                 countInputType = maybe 0 (const 1)
-              countInputType deposits + countInputType choices + countInputType notify 
+              countInputType deposits + countInputType choices + countInputType notify
 
             possibleInputChoices :: Maybe InputChoices
-            possibleInputChoices  =
+            possibleInputChoices =
               (DepositInputs <$> deposits)
                 <|> (ChoiceInputs <$> choices)
                 <|> (SpecificNotifyInput <$> notify)
@@ -414,7 +414,6 @@ nextRequest env state = do
     SubmittingTx { errors: Nothing, createTxResponse, txWitnessSet } ->
       Just $ RuntimeRequest $ SubmitTxRequest { txWitnessSet, createTxResponse, serverURL }
     _ -> Nothing
-
 
 -- This is pretty arbitrary choice - we should keep track which inputs are relevant
 -- during the further steps.

--- a/src/Component/ConnectWallet.purs
+++ b/src/Component/ConnectWallet.purs
@@ -60,7 +60,7 @@ type Props =
 renderWallets :: Effect Unit -> WalletInfo Wallet -> JSX
 renderWallets onSubmit (walletInfo@(WalletInfo { icon, name, wallet })) =
   DOM.div { className: "row mt-2" }
-    [ DOM.div { className: "col-12 d-flex rounded p-2 align-items-center border border-2 border-secondary justify-content-between cursor-pointer", onClick: handler_  onSubmit }
+    [ DOM.div { className: "col-12 d-flex rounded p-2 align-items-center border border-2 border-secondary justify-content-between cursor-pointer", onClick: handler_ onSubmit }
         [ DOOM.img { src: icon, alt: "Icon Before", className: "icon" }
         , DOM.span { className: "text-start" } $ DOOM.text name
         , DOM.div { className: "cardano-badge flex-8" }
@@ -186,34 +186,34 @@ mkConnectWallet = do
         ]
 
       else
-       -- [ DOM.div { className: "card p-5 m-5" }
-       --     [ DOM.p { className: "h3 font-weight-bold" } [ DOOM.text "Choose a wallet" ]
-       --     , DOM.span { className: "h5 text-muted" } [ DOOM.text "Please select a wallet to deploy a contract" ]
-       --     , formBody
-       --     , formActions
-       --     ]
-       --  ] <>
-       DOM.div { className: "container" } $ DOM.div { className: "row justify-content-center mt-4" }
-         [ DOM.div { className: "col-12" }
-             [ DOM.div { className: "card" }
-                 [ DOM.div { className: "card-body" }
-                     [ DOM.div { className: "container" }
-                         [ DOM.div { className: "row" }
-                             [ DOM.div { className: "col-12" }
-                                 [ DOM.h5 { className: "card-title font-weight-bold text-left" } [ DOOM.text "Choose a wallet" ]
-                                 , DOM.p { className: "card-help-text text-muted text-left" } [ DOOM.text "Please select a wallet to deploy a contract." ]
-                                 ]
-                             ]
-                         , case possibleWallets of
-                             Just wallets -> fragment $  (ArrayAL.toArray wallets) <#> \wallet -> do
-                               renderWallets (submit $ Just wallet) wallet
-                             Nothing -> mempty
-                         , DOM.div { className: "row mt-4 d-none" }
-                             [ DOM.div { className: "col-6 text-left p-0" } [ DOM.a { href: "#" } [ DOOM.text "Learn more" ] ]
-                             , DOM.div { className: "col-6 p-0" } [ DOM.a { href: "#", className: "text-muted text-right text-decoration-none" } [ DOOM.text "I don't have a wallet" ] ]
-                             ]
-                         ]
-                     ]
-                 ]
-             ]
-         ]
+        -- [ DOM.div { className: "card p-5 m-5" }
+        --     [ DOM.p { className: "h3 font-weight-bold" } [ DOOM.text "Choose a wallet" ]
+        --     , DOM.span { className: "h5 text-muted" } [ DOOM.text "Please select a wallet to deploy a contract" ]
+        --     , formBody
+        --     , formActions
+        --     ]
+        --  ] <>
+        DOM.div { className: "container" } $ DOM.div { className: "row justify-content-center mt-4" }
+          [ DOM.div { className: "col-12" }
+              [ DOM.div { className: "card" }
+                  [ DOM.div { className: "card-body" }
+                      [ DOM.div { className: "container" }
+                          [ DOM.div { className: "row" }
+                              [ DOM.div { className: "col-12" }
+                                  [ DOM.h5 { className: "card-title font-weight-bold text-left" } [ DOOM.text "Choose a wallet" ]
+                                  , DOM.p { className: "card-help-text text-muted text-left" } [ DOOM.text "Please select a wallet to deploy a contract." ]
+                                  ]
+                              ]
+                          , case possibleWallets of
+                              Just wallets -> fragment $ (ArrayAL.toArray wallets) <#> \wallet -> do
+                                renderWallets (submit $ Just wallet) wallet
+                              Nothing -> mempty
+                          , DOM.div { className: "row mt-4 d-none" }
+                              [ DOM.div { className: "col-6 text-left p-0" } [ DOM.a { href: "#" } [ DOOM.text "Learn more" ] ]
+                              , DOM.div { className: "col-6 p-0" } [ DOM.a { href: "#", className: "text-muted text-right text-decoration-none" } [ DOOM.text "I don't have a wallet" ] ]
+                              ]
+                          ]
+                      ]
+                  ]
+              ]
+          ]

--- a/src/Component/ContractList.purs
+++ b/src/Component/ContractList.purs
@@ -309,7 +309,7 @@ mkContractList = do
     pure $ DOM.div { className: "min-height-100vh" } do
       let
         onError error = do
-          msgHubProps.add $ Error $ DOOM.text $ fold [ "An error occured during contract submission: " <> error]
+          msgHubProps.add $ Error $ DOOM.text $ fold [ "An error occured during contract submission: " <> error ]
           resetModalAction
       case possibleModalAction, connectedWallet of
         Just (NewContract possibleInitialContract), Just cw -> createContractComponent
@@ -515,20 +515,20 @@ mkContractList = do
                         [ case possibleMarloweInfo of
                             Just (MarloweInfo { state, currentContract, initialContract, initialState }) -> do
                               DOM.a
-                                  do
-                                    let
-                                      onClick = setModalAction $ ContractDetails
-                                        { contract: currentContract
-                                        , state
-                                        , initialState: initialState
-                                        , initialContract: initialContract
-                                        , transactionEndpoints
-                                        }
-                                    { className: "cursor-pointer text-decoration-none text-reset text-decoration-underline-hover truncate-text w-16rem d-inline-block"
-                                    , onClick: handler_ onClick
-                                    }
-                                  [ text conractIdStr ]
-                            Nothing -> DOM.span {  className: "text-muted truncate-text w-16rem" } $ text conractIdStr
+                                do
+                                  let
+                                    onClick = setModalAction $ ContractDetails
+                                      { contract: currentContract
+                                      , state
+                                      , initialState: initialState
+                                      , initialContract: initialContract
+                                      , transactionEndpoints
+                                      }
+                                  { className: "cursor-pointer text-decoration-none text-reset text-decoration-underline-hover truncate-text w-16rem d-inline-block"
+                                  , onClick: handler_ onClick
+                                  }
+                                [ text conractIdStr ]
+                            Nothing -> DOM.span { className: "text-muted truncate-text w-16rem" } $ text conractIdStr
                         , DOM.a
                             { href: "#"
                             , onClick: handler_ copyToClipboard
@@ -575,13 +575,13 @@ mkContractList = do
                                         Monoid.guard
                                           (Array.any (\role -> canInput (V1.Role role) environment state contract) roles)
                                           buttonOutlinedPrimary
-                                            { label: DOOM.text "Advance"
-                                            , extraClassNames: "me-2"
-                                            , onClick: do
-                                                let
-                                                  marloweContext = { initialContract, state, contract }
-                                                setModalAction $ ApplyInputs ci transactionsEndpoint marloweContext
-                                            }
+                                          { label: DOOM.text "Advance"
+                                          , extraClassNames: "me-2"
+                                          , onClick: do
+                                              let
+                                                marloweContext = { initialContract, state, contract }
+                                              setModalAction $ ApplyInputs ci transactionsEndpoint marloweContext
+                                          }
                                       Just transactionsEndpoint,
                                       Just (MarloweInfo { initialContract, state: Just state, currentContract: Just contract }),
                                       Just { usedAddresses } -> do
@@ -593,10 +593,10 @@ mkContractList = do
                                         Monoid.guard
                                           (Array.any (\addr -> canInput (V1.Address $ bech32ToString addr) environment state contract) usedAddresses)
                                           buttonOutlinedPrimary
-                                            { label: DOOM.text "Advance"
-                                            , extraClassNames: "font-weight-bold btn-outline-primary"
-                                            , onClick: setModalAction $ ApplyInputs ci transactionsEndpoint marloweContext
-                                            }
+                                          { label: DOOM.text "Advance"
+                                          , extraClassNames: "font-weight-bold btn-outline-primary"
+                                          , onClick: setModalAction $ ApplyInputs ci transactionsEndpoint marloweContext
+                                          }
                                       _, Just (MarloweInfo { state: Nothing, currentContract: Nothing }), _ -> DOOM.text "Complete"
                                       _, _, _ -> buttonOutlinedInactive { label: DOOM.text "Syncing" }
 

--- a/src/Component/Types/ContractInfoMap.purs
+++ b/src/Component/Types/ContractInfoMap.purs
@@ -191,8 +191,7 @@ insertContractUpdated contractUpdated contractInfoMap = do
       UninitializedContractInfoMap _ -> Nothing
       ContractInfoMap { contractsSources } -> theseRight contractsSources
 
-  if isContractUpdateStillRelevant contractUpdated possiblySynced
-  then do
+  if isContractUpdateStillRelevant contractUpdated possiblySynced then do
     let
       notSyncedYet = addContractUpdated contractUpdated $ case contractInfoMap of
         UninitializedContractInfoMap _ -> emptyNotSyncedYet

--- a/src/Component/Widgets.purs
+++ b/src/Component/Widgets.purs
@@ -198,24 +198,23 @@ buttonOutlined props = do
 buttonOutlinedPrimary
   :: forall props
    . NoProblem.Coerce { coloring :: OutlineColoring | props } ButtonOutlinedProps
-   => Row.Lacks "coloring" props
-   => Row.Cons "coloring" OutlineColoring props (coloring :: OutlineColoring | props)
-   => { | props }
-   -> JSX
+  => Row.Lacks "coloring" props
+  => Row.Cons "coloring" OutlineColoring props (coloring :: OutlineColoring | props)
+  => { | props }
+  -> JSX
 buttonOutlinedPrimary props = do
   let
     props' :: { coloring :: OutlineColoring | props }
     props' = Record.insert (Proxy :: Proxy "coloring") OutlinePrimaryColoring props
   buttonOutlined props'
 
-
 buttonOutlinedInactive
   :: forall props
    . NoProblem.Coerce { coloring :: OutlineColoring | props } ButtonOutlinedProps
-   => Row.Lacks "coloring" props
-   => Row.Cons "coloring" OutlineColoring props (coloring :: OutlineColoring | props)
-   => { | props }
-   -> JSX
+  => Row.Lacks "coloring" props
+  => Row.Cons "coloring" OutlineColoring props (coloring :: OutlineColoring | props)
+  => { | props }
+  -> JSX
 buttonOutlinedInactive props = do
   let
     props' :: { coloring :: OutlineColoring | props }

--- a/src/Contrib/React/Basic/Hooks.purs
+++ b/src/Contrib/React/Basic/Hooks.purs
@@ -196,8 +196,8 @@ useVersionedStateWithRef
   :: forall a
    . a
   -> Hook
-      (UseVersionedStateWithRef a)
-      ({ state :: a, version :: Int } /\ Ref a /\ ((a -> a) -> Effect Unit))
+       (UseVersionedStateWithRef a)
+       ({ state :: a, version :: Int } /\ Ref a /\ ((a -> a) -> Effect Unit))
 useVersionedStateWithRef a = React.coerceHook React.do
   currState /\ updateState <- useVersionedState a
   stateRef <- useStateRef currState.version currState.state

--- a/src/Contrib/ReactBootstrap/FormSpecBuilders/StatlessFormSpecBuilders.purs
+++ b/src/Contrib/ReactBootstrap/FormSpecBuilders/StatlessFormSpecBuilders.purs
@@ -628,7 +628,7 @@ type TextAreaProps m a =
 renderTextArea
   :: { helpText :: Maybe JSX
      , possibleLabel :: Maybe JSX
-      , layout :: FieldLayout
+     , layout :: FieldLayout
      , name :: FieldId
      , placeholder :: String
      , rows :: Int
@@ -656,25 +656,26 @@ renderTextArea { extraClassName, layout, possibleLabel, helpText, name, placehol
               DOM.div { className: inputColClass }
         { errors: errors', isValid, isInvalid } = fieldValidity touched value errors
 
-      wrapper $ Form.Control.textArea
-        { id: nameStr
-        , name: nameStr
-        , placeholder
-        , value
-        , onChange: handler targetValue (onChange <<< fromMaybe "")
-        , rows
-        , isValid
-        , isInvalid
-        , className: fold extraClassName
-        }
-        <> do
-          fold
-            [ Monoid.guard isInvalid do
-                DOM.div { className: "invalid-feedback" }
-                  [ DOOM.ul_ $ map (DOOM.li_ <<< Array.singleton <<< DOOM.text) errors' ]
-            , Monoid.guard (isJust helpText && not isInvalid) $
-                renderPossibleHelpText helpText
-            ]
+      wrapper $
+        Form.Control.textArea
+          { id: nameStr
+          , name: nameStr
+          , placeholder
+          , value
+          , onChange: handler targetValue (onChange <<< fromMaybe "")
+          , rows
+          , isValid
+          , isInvalid
+          , className: fold extraClassName
+          }
+          <> do
+            fold
+              [ Monoid.guard isInvalid do
+                  DOM.div { className: "invalid-feedback" }
+                    [ DOOM.ul_ $ map (DOOM.li_ <<< Array.singleton <<< DOOM.text) errors' ]
+              , Monoid.guard (isJust helpText && not isInvalid) $
+                  renderPossibleHelpText helpText
+              ]
   DOM.div { className: "mb-2 row" } [ label, body ]
 
 textArea

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -127,7 +127,7 @@ main configJson = do
 
   let
     setPageClass :: Page -> Effect Unit
-    setPageClass  ContractListPage =
+    setPageClass ContractListPage =
       setAttribute "class" (origClasses <> " contract-list-page") appContainer
     setPageClass (CreateContractPage _) = do
       setAttribute "class" (origClasses <> " create-contract-page") appContainer


### PR DESCRIPTION
@zeme-wana, @shlevy, @paluh, basd on our Sept 27 conversation, I created the bash script [make-docker-image.sh](https://github.com/input-output-hk/marlowe-runner/blob/PLT-7563/make-docker-image.sh) that does the spago and webpack builds (from inside the `nix develop` shell) and then creates a Docker image.

The [Dockerfile](https://github.com/input-output-hk/marlowe-runner/blob/PLT-7563/Dockerfile) uses `sed` to edit in the correct `MARLOWE_WEB_SERVER_URL` just before launching `darkhttpd`.

Please review to see that this is sufficient for an interim deployment via docker.