### PR TITLE
Update nix documentation the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,19 @@ If you would like to use optimzed bundle of the project you can run t:
 MARLOWE_WEB_SERVER_URL="http://localhost:3780" npm run bundle
 ```
 
-## Building with Nix 
+## Development with Nix
+
+This repository uses nix to provide a development and build environment.
+
+If you know nix, simply run `nix develop` to enter the shell; if prompted, trust 
+the flake config values to enable access to our binary caches.   
+
+The nix code is based on a template from the the 
+[IOGX flake](https://github.com/input-output-hk/iogx). 
+For instructions on how to install and configure nix (including how to enable 
+access to our binary caches), and how keep the flake inputs up to date, refer to 
+[this section](https://github.com/input-output-hk/iogx/blob/main/doc/api.md#flakenix)
+of the IOGX manual.
 
 You can build the static site with Nix using:
 ```nix 
@@ -67,7 +79,7 @@ nix build .#marlowe-runner
 
 Whenever you make changes to `package-json.lock` or `packages.dhall` packages, you must run the 
 `gen-nix-lockfiles` script (available inside the `nix develop` shell) to 
-recreate `spago-packages.nix` and `npm-deps-hash.nix`.
+recreate `nix/spago-packages.nix` and `nix/npm-deps-hash.nix`.
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -62,15 +62,9 @@ MARLOWE_WEB_SERVER_URL="http://localhost:3780" npm run bundle
 
 This repository uses nix to provide a development and build environment.
 
-If you know nix, simply run `nix develop` to enter the shell; if prompted, trust 
-the flake config values to enable access to our binary caches.   
+For instructions on how to install and configure nix (including how to enable access to our binary caches), refer to [this document](https://github.com/input-output-hk/iogx/blob/main/doc/nix-setup-guide.md). 
 
-The nix code is based on a template from the the 
-[IOGX flake](https://github.com/input-output-hk/iogx). 
-For instructions on how to install and configure nix (including how to enable 
-access to our binary caches), and how keep the flake inputs up to date, refer to 
-[this section](https://github.com/input-output-hk/iogx/blob/main/doc/api.md#flakenix)
-of the IOGX manual.
+If you already have nix installed and configured, you may enter the development shell by running `nix develop`.
 
 You can build the static site with Nix using:
 ```nix 

--- a/flake.lock
+++ b/flake.lock
@@ -523,11 +523,11 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       },
       "locked": {
-        "lastModified": 1699460731,
-        "narHash": "sha256-WhMr0HPj1T+2lvH3Yh+fJq79MXYPnXofQ805JnQmI3k=",
+        "lastModified": 1699537966,
+        "narHash": "sha256-MGGza+vZDRjKj31WhQJDt7CqVVdrFkgkXIcqr0gDiU8=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "63deb643d7dfac8bf06b0d357caca742bd53ae07",
+        "rev": "c6ce7f034717ed0c0e9c6dd8fa2f898a15439627",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -518,16 +518,16 @@
           "haskell-nix",
           "nixpkgs"
         ],
-        "nixpkgs-with-working-prefetch-npm-deps": "nixpkgs-with-working-prefetch-npm-deps",
+        "nixpkgs-stable": "nixpkgs-stable",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       },
       "locked": {
-        "lastModified": 1698409584,
-        "narHash": "sha256-zqY9WIjs6ELYbyRwDx2w0hAgsV27b6TiAlMkCAQzSJ4=",
+        "lastModified": 1699460731,
+        "narHash": "sha256-WhMr0HPj1T+2lvH3Yh+fJq79MXYPnXofQ805JnQmI3k=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "da8ab3dc6d1500d4fe0aefe8fb7331edb3d49231",
+        "rev": "63deb643d7dfac8bf06b0d357caca742bd53ae07",
         "type": "github"
       },
       "original": {
@@ -744,6 +744,22 @@
     },
     "nixpkgs-stable": {
       "locked": {
+        "lastModified": 1690680713,
+        "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_2": {
+      "locked": {
         "lastModified": 1685801374,
         "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
         "owner": "NixOS",
@@ -771,22 +787,6 @@
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-with-working-prefetch-npm-deps": {
-      "locked": {
-        "lastModified": 1690680713,
-        "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
         "type": "github"
       }
     },
@@ -845,7 +845,7 @@
         "flake-utils": "flake-utils_3",
         "gitignore": "gitignore",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-stable": "nixpkgs-stable"
+        "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
         "lastModified": 1696846637,


### PR DESCRIPTION
Instructions on how to install & upgrade nix and how to setup the binary caches are now included in the [relevant section](https://github.com/input-output-hk/iogx/blob/main/doc/api.md#flakenix) of the IOGX manual. 
This PR updates the relevant sections of the README/CONTRIBUTING/RELEASE documents.
